### PR TITLE
reset connection_pool and retry on ReadOnlyError

### DIFF
--- a/bucket_monitor/redis_test.py
+++ b/bucket_monitor/redis_test.py
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""Tests for Redis client wrapper class"""
+"""Tests for RedisClient wrapper class"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -36,15 +36,32 @@ import pytest
 import bucket_monitor
 
 
+class ConnectionPool(object):
+
+    def reset(self, *_, **__):
+        pass
+
+
 class DummyRedis(object):
-    def __init__(self, fail_tolerance=0, hard_fail=False):
+
+    def __init__(self, fail_tolerance=0, hard_fail=False, read_only=False):
         self.fail_count = 0
         self.fail_tolerance = fail_tolerance
         self.hard_fail = hard_fail
+        self.read_only = read_only
+        self.reset_count = 0
+        self.connection_pool = ConnectionPool()
+        self.connection_pool.reset = self._incr_reset
+
+    def _incr_reset(self):
+        self.reset_count += 1
 
     def get_fail_count(self):
         if self.hard_fail:
             raise AssertionError('thrown on purpose')
+        if self.read_only and self.fail_count < self.fail_tolerance:
+            self.fail_count += 1
+            raise redis.exceptions.ReadOnlyError('READONLYERROR')
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
             raise redis.exceptions.ConnectionError('thrown on purpose')
@@ -55,15 +72,15 @@ class TestRedis(object):
 
     def test_redis_client(self):  # pylint: disable=R0201
         fails = random.randint(1, 3)
-        Redis = bucket_monitor.redis.RedisClient
+        RedisClient = bucket_monitor.redis.RedisClient
 
         # monkey patch _get_redis_client function to use DummyRedis client
         def _get_redis_client(*args, **kwargs):  # pylint: disable=W0613
             return DummyRedis(fail_tolerance=fails)
 
-        Redis._get_redis_client = _get_redis_client
+        RedisClient._get_redis_client = _get_redis_client
 
-        client = Redis(host='host', port='port', backoff=0)
+        client = RedisClient(host='host', port='port', backoff=0)
         assert client.get_fail_count() == fails
 
         with pytest.raises(AttributeError):
@@ -73,8 +90,18 @@ class TestRedis(object):
         def _get_redis_client_bad(*args, **kwargs):  # pylint: disable=W0613
             return DummyRedis(fail_tolerance=fails, hard_fail=True)
 
-        Redis._get_redis_client = _get_redis_client_bad
+        RedisClient._get_redis_client = _get_redis_client_bad
 
-        client = Redis(host='host', port='port', backoff=0)
+        client = RedisClient(host='host', port='port', backoff=0)
         with pytest.raises(AssertionError):
             client.get_fail_count()
+
+        # test READONLYERROR will reset the connection and retry
+        def _get_read_only_client(*args, **kwargs):  # pylint: disable=W0613
+            return DummyRedis(fail_tolerance=fails, read_only=True)
+
+        RedisClient._get_redis_client = _get_read_only_client
+
+        client = RedisClient(host='host', port='port', backoff=0)
+        assert client.get_fail_count() == fails
+        assert client._redis.reset_count == fails  # pylint: disable=E1101

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,6 @@ norecursedirs=
 # W503 line break occurred before a binary operator
 
 pep8ignore=* E731
+
+# Enable line length testing with maximum line length of 85
+pep8maxlinelength = 85


### PR DESCRIPTION
If attempting to write data to Redis using a connection to a `redis-ha` slave, a `ReadOnlyError` will be encountered.  This PR will catch the error, reset the connection using `connection_pool.reset`, and retry after `backoff` seconds.  Hopefully this will eventually use a connection that has write access.

Ideally, the client will immediately look up the master address, but I was unable to fix this in the short term.