### PR TITLE
Update the Redis client wrapper with Sentinel support 

### DIFF
--- a/bucket_monitor/redis.py
+++ b/bucket_monitor/redis.py
@@ -154,7 +154,8 @@ class RedisClient(object):
             self.logger.warning('Encountered Error: %s. Using sentinel as '
                                 'primary redis client.', err)
 
-    def _get_redis_client(self, host, port):  # pylint: disable=R0201
+    @classmethod
+    def _get_redis_client(cls, host, port):
         return redis.StrictRedis(host=host, port=port,
                                  decode_responses=True,
                                  charset='utf-8')

--- a/bucket_monitor/redis.py
+++ b/bucket_monitor/redis.py
@@ -28,10 +28,98 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
 import logging
+import time
+import random
 
 import redis
+
+
+REDIS_READONLY_COMMANDS = {
+    'publish',
+    'sunion',
+    'readonly',
+    'exists',
+    'hstrlen',
+    'lindex',
+    'scan',
+    'ping',
+    'ttl',
+    'wait',
+    'zscore',
+    'zrevrangebylex',
+    'sscan',
+    'geohash',
+    'getbit',
+    'hkeys',
+    'zrange',
+    'llen',
+    'auth',
+    'zcard',
+    'dbsize',
+    'subscribe',
+    'zrangebylex',
+    'zlexcount',
+    'mget',
+    'getrange',
+    'bitpos',
+    'lrange',
+    'discard',
+    'asking',
+    'client',
+    'pfselftest',
+    'unsubscribe',
+    'zrank',
+    'readwrite',
+    'hget',
+    'bitcount',
+    'randomkey',
+    'time',
+    'zrevrank',
+    'sinter',
+    'dump',
+    'strlen',
+    'unwatch',
+    'smembers',
+    'georadius',
+    'lastsave',
+    'slowlog',
+    'sismember',
+    'hexists',
+    'multi',
+    'sdiff',
+    'geopos',
+    'hscan',
+    'script',
+    'keys',
+    'hvals',
+    'pfcount',
+    'zscan',
+    'echo',
+    'command',
+    'select',
+    'zcount',
+    'substr',
+    'pttl',
+    'hlen',
+    'info',
+    'scard',
+    'geodist',
+    'srandmember',
+    'hgetall',
+    'pubsub',
+    'psubscribe',
+    'zrevrange',
+    'hmget',
+    'object',
+    'watch',
+    'zrangebyscore',
+    'get',
+    'type',
+    'zrevrangebyscore',
+    'punsubscribe',
+    'georadiusbymember',
+}
 
 
 class RedisClient(object):
@@ -39,23 +127,54 @@ class RedisClient(object):
     def __init__(self, host, port, backoff=1):
         self.logger = logging.getLogger(str(self.__class__.__name__))
         self.backoff = backoff
-        self._redis = self._get_redis_client(host=host, port=port)
+        self._sentinel = self._get_redis_client(host=host, port=port)
+        self._redis_master = self._sentinel
+        self._redis_slaves = [self._sentinel]
+        self._update_masters_and_slaves()
+
+    def _update_masters_and_slaves(self):
+        try:
+            self._sentinel.sentinel_masters()
+
+            sentinel_masters = self._sentinel.sentinel_masters()
+
+            for master_set in sentinel_masters:
+                master = sentinel_masters[master_set]
+
+                redis_master = self._get_redis_client(
+                    master['ip'], master['port'])
+
+                redis_slaves = []
+                for slave in self._sentinel.sentinel_slaves(master_set):
+                    redis_slave = self._get_redis_client(
+                        slave['ip'], slave['port'])
+                    redis_slaves.append(redis_slave)
+
+                self._redis_slaves = redis_slaves
+                self._redis_master = redis_master
+        except redis.exceptions.ResponseError as err:
+            self.logger.warning('Encountered Error: %s. Using sentinel as '
+                                'primary redis client.', err)
 
     def _get_redis_client(self, host, port):  # pylint: disable=R0201
-        return redis.StrictRedis(
-            host=host, port=port,
-            decode_responses=True,
-            charset='utf-8')
+        return redis.StrictRedis(host=host, port=port,
+                                 decode_responses=True,
+                                 charset='utf-8')
 
     def __getattr__(self, name):
-        redis_function = getattr(self._redis, name)
+        if name in REDIS_READONLY_COMMANDS:
+            redis_client = random.choice(self._redis_slaves)
+        else:
+            redis_client = self._redis_master
+
+        redis_function = getattr(redis_client, name)
 
         def wrapper(*args, **kwargs):
+            values = list(args) + list(kwargs.values())
             while True:
                 try:
                     return redis_function(*args, **kwargs)
                 except redis.exceptions.ConnectionError as err:
-                    values = list(args) + list(kwargs.values())
                     self.logger.warning('Encountered %s: %s when calling '
                                         '`%s %s`. Retrying in %s seconds.',
                                         type(err).__name__, err,
@@ -63,9 +182,9 @@ class RedisClient(object):
                                         ' '.join(values), self.backoff)
                     time.sleep(self.backoff)
                 except Exception as err:
-                    self.logger.error('Unexpected %s: %s when calling %s.',
+                    self.logger.error('Unexpected %s: %s when calling `%s %s`.',
                                       type(err).__name__, err,
-                                      str(name).upper())
+                                      str(name).upper(), ' '.join(values))
                     raise err
 
         return wrapper

--- a/bucket_monitor/redis.py
+++ b/bucket_monitor/redis.py
@@ -134,8 +134,6 @@ class RedisClient(object):
 
     def _update_masters_and_slaves(self):
         try:
-            self._sentinel.sentinel_masters()
-
             sentinel_masters = self._sentinel.sentinel_masters()
 
             for master_set in sentinel_masters:
@@ -162,20 +160,21 @@ class RedisClient(object):
                                  charset='utf-8')
 
     def __getattr__(self, name):
-        if name in REDIS_READONLY_COMMANDS:
-            redis_client = random.choice(self._redis_slaves)
-        else:
-            redis_client = self._redis_master
-
-        redis_function = getattr(redis_client, name)
 
         def wrapper(*args, **kwargs):
             values = list(args) + list(kwargs.values())
             values = [str(v) for v in values]
             while True:
                 try:
+                    if name in REDIS_READONLY_COMMANDS:
+                        redis_client = random.choice(self._redis_slaves)
+                    else:
+                        redis_client = self._redis_master
+
+                    redis_function = getattr(redis_client, name)
                     return redis_function(*args, **kwargs)
                 except redis.exceptions.ConnectionError as err:
+                    self._update_masters_and_slaves()
                     self.logger.warning('Encountered %s: %s when calling '
                                         '`%s %s`. Retrying in %s seconds.',
                                         type(err).__name__, err,

--- a/bucket_monitor/redis.py
+++ b/bucket_monitor/redis.py
@@ -171,6 +171,7 @@ class RedisClient(object):
 
         def wrapper(*args, **kwargs):
             values = list(args) + list(kwargs.values())
+            values = [str(v) for v in values]
             while True:
                 try:
                     return redis_function(*args, **kwargs)
@@ -181,6 +182,17 @@ class RedisClient(object):
                                         str(name).upper(),
                                         ' '.join(values), self.backoff)
                     time.sleep(self.backoff)
+                except redis.exceptions.ResponseError as err:
+                    # check if redis just needs a backoff
+                    if 'BUSY' in str(err) and 'SCRIPT KILL' in str(err):
+                        self.logger.warning('Encountered %s: %s when calling '
+                                            '`%s %s`. Retrying in %s seconds.',
+                                            type(err).__name__, err,
+                                            str(name).upper(),
+                                            ' '.join(values), self.backoff)
+                        time.sleep(self.backoff)
+                    else:
+                        raise err
                 except Exception as err:
                     self.logger.error('Unexpected %s: %s when calling `%s %s`.',
                                       type(err).__name__, err,

--- a/bucket_monitor/redis_test.py
+++ b/bucket_monitor/redis_test.py
@@ -36,9 +36,11 @@ import pytest
 import bucket_monitor
 
 
+FAIL_COUNT = 0
+
+
 class DummyRedis(object):
     def __init__(self, fail_tolerance=0, hard_fail=False, err=None):
-        self.fail_count = 0
         self.fail_tolerance = fail_tolerance
         self.hard_fail = hard_fail
         if err is None:
@@ -46,12 +48,13 @@ class DummyRedis(object):
         self.err = err
 
     def get_fail_count(self):
+        global FAIL_COUNT
         if self.hard_fail:
             raise AssertionError('thrown on purpose')
-        if self.fail_count < self.fail_tolerance:
-            self.fail_count += 1
+        if FAIL_COUNT < self.fail_tolerance:
+            FAIL_COUNT += 1
             raise self.err
-        return self.fail_count
+        return FAIL_COUNT
 
     def sentinel_masters(self):
         return {'mymaster': {'ip': 'master', 'port': 6379}}
@@ -64,6 +67,8 @@ class DummyRedis(object):
 class TestRedis(object):
 
     def test_redis_client(self):  # pylint: disable=R0201
+        global FAIL_COUNT
+
         fails = random.randint(1, 3)
         RedisClient = bucket_monitor.redis.RedisClient
 
@@ -75,6 +80,7 @@ class TestRedis(object):
 
         client = RedisClient(host='host', port='port', backoff=0)
         assert client.get_fail_count() == fails
+        FAIL_COUNT = 0  # reset for the next test
 
         with pytest.raises(AttributeError):
             client.unknown_function()
@@ -88,6 +94,7 @@ class TestRedis(object):
 
         client = RedisClient(host='host', port='port', backoff=0)
         assert client.get_fail_count() == fails
+        FAIL_COUNT = 0  # reset for the next test
 
         # test ResponseError other - should fail
         def _get_redis_client_err(*args, **kwargs):  # pylint: disable=W0613

--- a/bucket_monitor/redis_test.py
+++ b/bucket_monitor/redis_test.py
@@ -37,44 +37,75 @@ import bucket_monitor
 
 
 class DummyRedis(object):
-    def __init__(self, fail_tolerance=0, hard_fail=False):
+    def __init__(self, fail_tolerance=0, hard_fail=False, err=None):
         self.fail_count = 0
         self.fail_tolerance = fail_tolerance
         self.hard_fail = hard_fail
+        if err is None:
+            err = redis.exceptions.ConnectionError('thrown on purpose')
+        self.err = err
 
     def get_fail_count(self):
         if self.hard_fail:
             raise AssertionError('thrown on purpose')
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
-            raise redis.exceptions.ConnectionError('thrown on purpose')
+            raise self.err
         return self.fail_count
+
+    def sentinel_masters(self):
+        return {'mymaster': {'ip': 'master', 'port': 6379}}
+
+    def sentinel_slaves(self, _):
+        n = random.randint(1, 4)
+        return [{'ip': 'slave', 'port': 6379} for i in range(n)]
 
 
 class TestRedis(object):
 
     def test_redis_client(self):  # pylint: disable=R0201
         fails = random.randint(1, 3)
-        Redis = bucket_monitor.redis.RedisClient
+        RedisClient = bucket_monitor.redis.RedisClient
 
         # monkey patch _get_redis_client function to use DummyRedis client
         def _get_redis_client(*args, **kwargs):  # pylint: disable=W0613
             return DummyRedis(fail_tolerance=fails)
 
-        Redis._get_redis_client = _get_redis_client
+        RedisClient._get_redis_client = _get_redis_client
 
-        client = Redis(host='host', port='port', backoff=0)
+        client = RedisClient(host='host', port='port', backoff=0)
         assert client.get_fail_count() == fails
 
         with pytest.raises(AttributeError):
             client.unknown_function()
 
+        # test ResponseError BUSY - should retry
+        def _get_redis_client_retry(*args, **kwargs):  # pylint: disable=W0613
+            err = redis.exceptions.ResponseError('BUSY SCRIPT KILL')
+            return DummyRedis(fail_tolerance=fails, err=err)
+
+        RedisClient._get_redis_client = _get_redis_client_retry
+
+        client = RedisClient(host='host', port='port', backoff=0)
+        assert client.get_fail_count() == fails
+
+        # test ResponseError other - should fail
+        def _get_redis_client_err(*args, **kwargs):  # pylint: disable=W0613
+            err = redis.exceptions.ResponseError('OTHER ERROR')
+            return DummyRedis(fail_tolerance=fails, err=err)
+
+        RedisClient._get_redis_client = _get_redis_client_err
+        client = RedisClient(host='host', port='port', backoff=0)
+
+        with pytest.raises(redis.exceptions.ResponseError):
+            client.get_fail_count()
+
         # test that other exceptions will raise.
         def _get_redis_client_bad(*args, **kwargs):  # pylint: disable=W0613
             return DummyRedis(fail_tolerance=fails, hard_fail=True)
 
-        Redis._get_redis_client = _get_redis_client_bad
+        RedisClient._get_redis_client = _get_redis_client_bad
 
-        client = Redis(host='host', port='port', backoff=0)
+        client = RedisClient(host='host', port='port', backoff=0)
         with pytest.raises(AssertionError):
             client.get_fail_count()

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,6 @@ norecursedirs=
 # W503 line break occurred before a binary operator
 
 pep8ignore=* E731
+
+# Enable line length testing with maximum line length of 85
+pep8maxlinelength = 85


### PR DESCRIPTION
The Redis client now uses Sentinel to route READONLY requests to the slave nodes and WRITE request to the master node.