### PR TITLE
Use pytest-mock for better mocking in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache: pip
 
 install:
   - pip install -r requirements.txt
-  - pip install pytest pytest-cov pytest-pep8 pytest-mock coveralls
+  - pip install pytest pytest-cov==2.5.1 pytest-pep8 pytest-mock coveralls
 
 script:
   - pytest --cov=bucket_monitor --pep8 bucket_monitor

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache: pip
 
 install:
   - pip install -r requirements.txt
-  - pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
+  - pip install pytest pytest-cov pytest-pep8 pytest-mock coveralls
 
 script:
   - pytest --cov=bucket_monitor --pep8 bucket_monitor


### PR DESCRIPTION
This PR directly mocks `google.cloud.storage.Client` instead of monkey-patching the `get_storage_api` method.