### PR TITLE
Bugfix: Install required alpine packages for google-cloud-storage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -106,3 +106,6 @@ venv.bak/
 # OS Files
 .DS_Store
 .vscode
+
+# GitHub Workflows
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,14 @@ WORKDIR /usr/src/app
 
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt
+# install dependencies for google-cloud-storage
+# https://github.com/googleapis/python-storage/issues/216#issuecomment-671279940
+RUN apk add --no-cache --virtual .build-deps \
+    gcc \
+    musl-dev \
+    libffi-dev \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apk del .build-deps
 
 COPY . .
 


### PR DESCRIPTION
Install required `alpine` dependencies to install `google-cloud-storage`, namely:

* `gcc`
* `musl-dev`
* `libffi-dev`

These are installed before the `pip` dependencies and removed in the same step to minimize image size.