### PR TITLE
Replace BUCKET and CLOUD_PROVIDER with STORAGE_BUCKET.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ The bucket monitor is configured using environment variables. Please find a tabl
 
 | Name | Description | Default Value |
 | :--- | :--- | :--- |
-| `BUCKET` | **REQUIRED**: The name of the bucket to monitor. | `""` |
+| `STORAGE_BUCKET` | **REQUIRED**: The name of the bucket to monitor. | `""` |
 | `AGE_THRESHOLD` | Files are removed if they are older than this many seconds. | `259200` |
-| `CLOUD_PROVIDER` | The cloud provider hosting the DeepCell Kiosk | `"gke"` |
 | `INTERVAL` | How frequently the bucket is monitored, in seconds. | `21600` |
 | `PREFIXES` | A comma separated string of the bucket's directories to monitor. | `"uploads/,output/"` |
 

--- a/monitor-bucket.py
+++ b/monitor-bucket.py
@@ -82,13 +82,11 @@ if __name__ == '__main__':
     #
     # MONITOR = bucket_monitor.BucketMonitor(
     #     redis_client=REDIS,
-    #     cloud_provider=os.getenv('CLOUD_PROVIDER'),
-    #     bucket_name=os.getenv('BUCKET'),
+    #     bucket=os.getenv('STORAGE_BUCKET'),
     #     queue=os.getenv('QUEUE', 'predict'))
 
     MONITOR = bucket_monitor.StaleFileBucketMonitor(
-        cloud_provider=os.getenv('CLOUD_PROVIDER'),
-        bucket_name=os.getenv('BUCKET'))
+        bucket=os.getenv('STORAGE_BUCKET'))
 
     while True:
         for prefix in PREFIXES:

--- a/monitor-bucket.py
+++ b/monitor-bucket.py
@@ -41,29 +41,27 @@ import logging.handlers
 import bucket_monitor
 
 
-def initialize_logger(debug_mode=True):
+def initialize_logger(log_level='DEBUG'):
+    log_level = str(log_level).upper()
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
 
-    formatter = logging.Formatter(
-        '[%(asctime)s]:[%(levelname)s]:[%(name)s]: %(message)s')
+    formatter = logging.Formatter('[%(levelname)s]:[%(name)s]: %(message)s')
     console = logging.StreamHandler(stream=sys.stdout)
     console.setFormatter(formatter)
 
-    fh = logging.handlers.RotatingFileHandler(
-        filename='bucket-monitor.log',
-        maxBytes=10000000,
-        backupCount=10)
-    fh.setFormatter(formatter)
-
-    if debug_mode:
-        console.setLevel(logging.DEBUG)
-    else:
+    if log_level == 'CRITICAL':
+        console.setLevel(logging.CRITICAL)
+    elif log_level == 'ERROR':
+        console.setLevel(logging.ERROR)
+    elif log_level == 'WARN':
+        console.setLevel(logging.WARN)
+    elif log_level == 'INFO':
         console.setLevel(logging.INFO)
-    fh.setLevel(logging.DEBUG)
+    else:
+        console.setLevel(logging.DEBUG)
 
     logger.addHandler(console)
-    logger.addHandler(fh)
 
 
 if __name__ == '__main__':
@@ -71,7 +69,7 @@ if __name__ == '__main__':
     PREFIXES = os.getenv('PREFIX', 'uploads/,output/').split(',')
     AGE_THRESHOLD = int(os.getenv('AGE_THRESHOLD', str(3 * 24 * 60 * 60)))
 
-    initialize_logger(os.getenv('DEBUG'))
+    initialize_logger(os.getenv('LOG_LEVEL', 'DEBUG'))
 
     _logger = logging.getLogger(__file__)
 


### PR DESCRIPTION
Using a single `STORAGE_BUCKET` environment variable allows us to infer the `CLOUD_PROVIDER` and reduce the total number of environment variables. This also aligns more closely with vanvalenlab/kiosk-tf-serving#41.

Change `DEBUG` to `LOG_LEVEL` and prevent logs from writing to local files (console only).