### PR TITLE
Update `redis` and `google-cloud-storage` versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 google-cloud-storage>=1.15.0,<2
+redis>=3.4.1,<4
 pytz==2019.1


### PR DESCRIPTION
Upgrade `redis` to match other Kiosk components, and upgrade `google-cloud-storage` to allow future updates (this is currently ~30 minor versions behind).